### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,6 +3,7 @@ author=bibi21000
 email=Sébastien GALLET <bibi21000@gmail.com>
 sentence=IP protocols
 paragraph=implements IP protocols like HTTP, FTP, SMTP, ...
+category=Communication
 url=https://github.com/bibi21000/fullip
 architectures=avr
 version=1.00


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library FullIP is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6 and 1.6.7. If you disagree with my category choice I'm happy to change the category to any of the other [valid category values](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) and squash to a single commit.
